### PR TITLE
ltcgenerator.cpp - add ltc!start@hh:mm:ss:ff

### DIFF
--- a/lib-ltc/src/h3/ltcgenerator.cpp
+++ b/lib-ltc/src/h3/ltcgenerator.cpp
@@ -360,6 +360,11 @@ void LtcGenerator::HandleUdpRequest(void) {
 			ActionSetStart((const char *)&m_Buffer[(4 + START_LENGTH + 1)]);
 			ActionStop();
 			ActionStart();
+		} else if ((m_nBytesReceived == (4 + START_LENGTH + 1 + TC_CODE_MAX_LENGTH)) && (m_Buffer[4 + START_LENGTH] == '@')){
+			ActionStop();
+			ActionSetStart((const char *)&m_Buffer[(4 + START_LENGTH + 1)]);			
+			ActionStart();
+			ActionStop();			
 		} else {
 			DEBUG_PUTS("Invalid !start command");
 		}


### PR DESCRIPTION
the @ operator stops output, set start to the new hh:mm:ss:ff, and then does a start-stop, to timewarp the output to this exact frame.  
After this command, we are stopped, and waiting for a !start.     
This is ideal for scrubbing around on a timeline in an editor.

I thought about using ltc!stop#command, but that would change the stop time, which is not what I am trying to do really, then I thought a new ltc!jump command, but really not worth it.   Then I thought,  swap the '!' command with the '@' command.   What do you think?