### PR TITLE
Added hardware interface to re-enable display after timeout

### DIFF
--- a/opi_emac_artnet_dmx_multi/firmware/main.cpp
+++ b/opi_emac_artnet_dmx_multi/firmware/main.cpp
@@ -40,6 +40,7 @@
 #include "displayudfparams.h"
 #include "artnet/displayudfhandler.h"
 #include "displayhandler.h"
+#include "display_timeout.h"
 
 #include "artnet4node.h"
 #include "artnetparams.h"
@@ -75,6 +76,7 @@ using namespace artnet;
 extern "C" {
 
 void notmain(void) {
+	display_timeout_init();
 	Hardware hw;
 	Network nw;
 	LedBlink lb;
@@ -266,6 +268,8 @@ void notmain(void) {
 		remoteConfig.Run();
 		spiFlashStore.Flash();
 		lb.Run();
+		if(display.isSleep() && renew_timeout())
+			display.SetSleep(false);
 		display.Run();
 		if (pDmxConfigUdp != nullptr) {
 			pDmxConfigUdp->Run();

--- a/opi_emac_artnet_dmx_multi/include/display_timeout.h
+++ b/opi_emac_artnet_dmx_multi/include/display_timeout.h
@@ -1,0 +1,45 @@
+/**
+ * @file display_timeout.h
+ *
+ */
+/* Copyright (C) 2021 by Arjan van Vught mailto:info@gd32-dmx.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef DISPLAY_TIMEOUT_H_
+#define DISPLAY_TIMEOUT_H_
+
+#include "h3_gpio.h"
+
+#define BUTTON_GPIO	H3_PORT_TO_GPIO(H3_GPIO_PORTA, 3)
+
+void display_timeout_init() {
+	h3_gpio_fsel(BUTTON_GPIO, GPIO_FSEL_INPUT);
+	h3_gpio_pud(BUTTON_GPIO, GPIO_PULL_UP);
+}
+
+bool renew_timeout() {
+	const auto nLevel = h3_gpio_lev(BUTTON_GPIO);
+    const auto renewTimeout = (nLevel == LOW);
+
+    return renewTimeout;
+}
+
+#endif /* IS_CONFIG_MODE_H_ */


### PR DESCRIPTION
I wanted to have a button on my rack to re-enable the display after the specified timeout.
The "display_timeout.h" file is in the same style as the "/opi_rdm_responder/include/is_config_mode.h" file.

It would be great if you could merge this request and maybe add it to all projects with a display.

Greetings, Daniel